### PR TITLE
docs: fix typos

### DIFF
--- a/articles/scudo_internals.html
+++ b/articles/scudo_internals.html
@@ -71,7 +71,7 @@ between different platforms.
 Scudo is really two things, the Primary Allocator and the Secondary allocator.
 ~ The primary allocator is responsible for smaller allocation needs of a process.
   So for the most part, this is the allocator used.
-~ The secondary allocator on the other hand, services the more hungry needs 
+~ The secondary allocator on the other hand, services the more hungry needs
   of a process.
 
 There are various concepts that add up in a good heap layout, some of them are:
@@ -124,14 +124,14 @@ to allocate space on that region for storing user data.
 
 Depending how it is bundled with the standard libc/C++ library on a given
 platform, scudo might be initialized either during startup or during the first
-scudo allocation operation. On the linux platform scudo is not hardwired with 
+scudo allocation operation. On the linux platform scudo is not hardwired with
 the glibc by default and so it requires you to link scudo in some way before
 running a program.
 
 For our testing we compiled the standalone scudo library for linux and used the
 RPATH property to load scudo on our testbeds.
 
-The initialization of the heap will take place on the first allocation 
+The initialization of the heap will take place on the first allocation
 operation. The function responsible for this is initThreadMaybe.
 
 --------------------------------- tsd_exclusive.h ---------------------------------
@@ -173,7 +173,7 @@ secure source of randomness where it's needed.
 The flags will then be parsed, which manage certain behaviours of scudo.
 e.g; whether to implicitly zero the contents of a block etc.
 
-While testing we have enabled Quarantine by setting the following flags 
+While testing we have enabled Quarantine by setting the following flags
 in the SCUDO_OPTIONS environment variable.
 
 * quarantine_size_kb - "Size (in bytes) up to which chunks can be quarantined."
@@ -182,7 +182,7 @@ in the SCUDO_OPTIONS environment variable.
 * thread_local_quarantine_size_kb - "The size (in Kb) of per-thread cache use
   to offload the global quarantine."
 
-When all this is done, Primary.init will be called for further initialization 
+When all this is done, Primary.init will be called for further initialization
 of the primary allocator.
 
 ----------------------------------- primary64.h -----------------------------------
@@ -229,10 +229,10 @@ After mapping the heap, a new 32 bit random integer will be read from
 /dev/urandom. This value will be used as an additional source of entropy
 as well as for deriving RandStates for each Region.
 
-Finally, it can be configured that the start of each Region will be randomized 
-by an offset of [1, 16] * PageSize, to make it harder for an attacker to guess 
-their location, but also to introduce guard pages between them. 
-Those gaps between each region are reserved unreadable & unwritable. 
+Finally, it can be configured that the start of each Region will be randomized
+by an offset of [1, 16] * PageSize, to make it harder for an attacker to guess
+their location, but also to introduce guard pages between them.
+Those gaps between each region are reserved unreadable & unwritable.
 With this trick, huge heap overflows could be prevented.
 
    Start of the heap.
@@ -279,7 +279,7 @@ With this trick, huge heap overflows could be prevented.
 
 <span id="a3_2"></span>---[ 3.2 - The birth of a block.
 
-Continuing our journey after the initialization of the heap, scudo is now 
+Continuing our journey after the initialization of the heap, scudo is now
 ready to service our request.
 
 ----------------------------------- combined.h -----------------------------------
@@ -324,7 +324,7 @@ NOINLINE void *allocate(uptr Size, Chunk::Origin Origin,
 
 The first thing scudo has to decide is what allocator to use to service our
 request. If our request is too big for the primary allocator, canAllocate()
-will return false and Secondary Allocator will be used. 
+will return false and Secondary Allocator will be used.
 We will focus only on the Primary.
 
 The next thing that needs to be resolved is which region shall service the
@@ -355,7 +355,7 @@ Here is a table for the first 6 regions:
 <span id="a3_2_1"></span>----[ 3.2.1 - Checking for orphans first
 
 When it has been figured out which region shall service the request, the
-cache of the allocator will be checked for any available free blocks in 
+cache of the allocator will be checked for any available free blocks in
 the specified region before attempting to map more space for the heap.
 
 ---------------------------------- local_cache.h ----------------------------------
@@ -373,7 +373,7 @@ void *allocate(uptr ClassId) {
 }
 ----------------------------------------------------------------------------------
 
-Each region holds a PerClass entry in the PerClassArray for tracking 
+Each region holds a PerClass entry in the PerClassArray for tracking
 available free blocks in a compact format.
 
   ...
@@ -389,7 +389,7 @@ available free blocks in a compact format.
   PerClass PerClassArray[NumClasses] = {};
   ...
 
-Each PerClass entry can hold up to 2 * TransferBatch::MaxNumCached free 
+Each PerClass entry can hold up to 2 * TransferBatch::MaxNumCached free
 blocks. Double the amount of blocks that a TransferBatch can hold.
 
   ...
@@ -430,7 +430,7 @@ following structure.
     };
   ...
 
-So returning back to allocate(), if the cache is not empty, scudo will 
+So returning back to allocate(), if the cache is not empty, scudo will
 "decompact" the last free block pointer stored in the PerClass entry and
 return it back to the program.
 
@@ -644,7 +644,7 @@ see above there is no need for shuffling the transfer batches in Region 0.
 
 <span id="a3_2_3"></span>----[ 3.2.3 - Integrity checks on the header.
 
-The last step before returning a block back to the program is to prepend 
+The last step before returning a block back to the program is to prepend
 a header for tracking some information for the block.
 
                          Block header
@@ -694,7 +694,7 @@ ensures the integrity of the header and protects from potential corruption.
 It is checked each time the block is being freed.
 
 The checksum for each block is produced as a CRC32 of the Cookie, the heap
-address of the block and the contents of it's header (without the checksum).
+address of the block and the contents of its header (without the checksum).
 With this way although an attacker may control the contents of the header,
 but he needs also a Cookie and a heap leak in order to produce his own valid
 checksums.
@@ -782,13 +782,13 @@ void quarantineOrDeallocateChunk(Options Options, void *TaggedPtr,
 Scudo decides whether to put a block in the Quarantine or back in the Cache with
 the help of the 'BypassQuarantine' condition. This condition will decide the fate
 of the block. If the Quarantine is enabled and hence Quarantine.getCacheSize() > 0,
-the fate of the block depends mostly upon it's size. Blocks that are being handled
+the fate of the block depends mostly upon its size. Blocks that are being handled
 by the Secondary allocator are assigned with a ClassId = 0 and they bypass the
 Quarantine.
 
-So a block of the primary allocator bypasses the Quarantine only when it's size is
+So a block of the primary allocator bypasses the Quarantine only when its size is
 less than the QuarantineMaxChunkSize threshold. For this section we will focus on
-the primary blocks that suprass this threshold. We will describe the Quarantine
+the primary blocks that surpass this threshold. We will describe the Quarantine
 separately in the following section.
 
 Eventually for such primary blocks, TSD->Cache.deallocate() will be called;
@@ -870,7 +870,7 @@ QuarantineCache contents;
   ~ Size, counter of how many QuarantineBatches are linked in this list.
   ~ First, first node in the linked list.
   ~ Last, last node in the linked list.
-~ Size: this is the total size of quarantined nodes 
+~ Size: this is the total size of quarantined nodes
   recorded in every QuarantineBatch that is linked in the List.
 
 
@@ -878,7 +878,7 @@ QuarantineCache contents;
 
 When calling free() API, quarantineOrDeallocateChunk() method will
 be called internally, which will firstly do some checks if it should
-quarantine the chunk or not (dah!). The following code snippet is the 
+quarantine the chunk or not (dah!). The following code snippet is the
 part that is executed when it has figured to quarantine the chunk.
 
 ----------------------------------- combined.h -----------------------------------
@@ -892,14 +892,14 @@ else {
 }
 ----------------------------------------------------------------------------------
 
-The put method of a GlobalQuarantine object will be called with the 
+The put method of a GlobalQuarantine object will be called with the
 following arguments;
 ~ A QuarantineCache object pointer from the thread specific
   data region.
 ~ A QuarantineCallback object. [*]
 ~ Pointer to the to-be-quarantined-chunk.
 ~ Size of the to-be-quarantined-chunk.
-  
+
 [*]:
 ---------------------------------- quarantine.h ----------------------------------
 
@@ -919,7 +919,7 @@ void put(CacheT *C, Callback Cb, Node *Ptr, uptr Size) {
 }
 ----------------------------------------------------------------------------------
 
-enqueue method will push the to-be-quarantined chunk pointer to the 
+enqueue method will push the to-be-quarantined chunk pointer to the
 "delayed freelist".
 
 ---------------------------------- quarantine.h ----------------------------------
@@ -943,7 +943,7 @@ object in the List is full, it will create a new one that its buffer
 is allocated like a normal chunk and initialize it by placing our
 to-be-quarantined-chunk pointer in the *Batch[]. it will then set the
 Count & Size variables to the appropriate value.
-Lastly it enqueues the new QuarantineBatch to the List and update the 
+Lastly it enqueues the new QuarantineBatch to the List and update the
 Size variable of the QuarantineCache object.
 
 On the other hand, it will just be stored in the *Batch[] of the last List
@@ -966,7 +966,7 @@ void put(CacheT *C, Callback Cb, Node *Ptr, uptr Size) {
 ----------------------------------------------------------------------------------
 
 This if statement is checking if the total memory used (including internal accounting)
-has exceeded MaxCacheSize. If it has, call drain. Which will merge the thread local 
+has exceeded MaxCacheSize. If it has, call drain. Which will merge the thread local
 QuarantineCache object to the GlobalQuarantine's QuarantineCache object;
 
 ---------------------------------- quarantine.h ----------------------------------
@@ -1017,7 +1017,7 @@ void NOINLINE recycle(uptr MinSize, Callback Cb) {
 ----------------------------------------------------------------------------------
 
 The if statement tries to guess if it's likely to find batches suitable
-for merge in this QuarantineBatch List. If it is, call mergeBatches() 
+for merge in this QuarantineBatch List. If it is, call mergeBatches()
 which will try merging batches to save up some memory.
 
 The last call will be to doRecycle() which will unquarantine the nodes


### PR DESCRIPTION
The typos are just bad usages of `it's` when it should be `its`, and `suprass` -> `surpass`, I also removed unnecessary spaces (seems like my autoformatter did that, no harm in that, right? ;) ) 

This was a really informative and cool article, so props to you both for this; I got to learn quite a bit about Scudo that might help me in debugging a crash someone reported to us at tree-sitter when using this allocator 😁 (and I learned what the hell the primary/secondary bits meant in proc/{TID}/maps whenever I saw that when reverse engineering android stuff!)
